### PR TITLE
Search all module paths for the adapter executable

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var urlparse = require('url').parse
 var urlformat = require('url').format
 var child_process = require('child_process')
 var path = require('path')
+var fs = require('fs');
 var os = require('os')
 
 function launch(url, options, callback) {
@@ -15,13 +16,20 @@ function launch(url, options, callback) {
     args.push('-l ' + url)
   }
 
-  var adapterPath = path.resolve('node_modules', 'edge-diagnostics-adapter', 'dist', os.arch(), 'EdgeDiagnosticsAdapter.exe')
 
   if (options.adapterPath) {
-    adapterPath = options.adapterPath
+    var command = options.adapterPath
+  } else {
+    for (var i = 0; i < module.paths.length; i++) {
+      var command = path.resolve(module.paths[i], 'edge-diagnostics-adapter',
+                                 'dist', os.arch(), 'EdgeDiagnosticsAdapter.exe')
+
+      if (fs.existsSync(command)) {
+        break;
+      }
+    }
   }
 
-  var command = adapterPath
   var process = child_process.spawn(command, args)
 
   if (callback) {


### PR DESCRIPTION
Resolving relative to the current working directory won't do much good (as in it will fail once you install this as a module in another module).

In other words, this happens

``` console
$ git clone https://github.com/microsoft/edge-diagnostics-launch.git
$ cd edge-diagnostics-launch/examples
$ node example

Error: spawn .../edge-diagnostics-launch/examples/node_modules/edge-diagnostics-adapter/dist/x64/EdgeDiagnosticsAdapter.exe ENOENT
```

This searches through all the paths in `module.paths` for the adapter
instead.  Should work with both npm v2 and npm v3 as all the directories are checked from the most local to the least local.
